### PR TITLE
Make the non-existing file in layout.blade within project

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -2,7 +2,7 @@
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Foundation\Vite as ViteFoundation;
 
-$nonExistentFileName = '/vendor/horizon/nonExistentFile';
+$nonExistentFileName = 'vendor/horizon/nonExistentFile';
 
 $vite = new ViteFoundation();
 $vite->useHotFile($nonExistentFileName);


### PR DESCRIPTION
If the PHPs `open_basedir` value is configured, any check for a file outside of given scope causes  `is_file(): open_basedir restriction in effect. File(/vendor/horizon/nonExistentFile) is not within the allowed path(s):` error, which prevents the UI from loading.

